### PR TITLE
Manually specify ID `why-two-colons` for "Why `::`?" section

### DIFF
--- a/content/specifications/v0.1.0.md
+++ b/content/specifications/v0.1.0.md
@@ -235,7 +235,7 @@ empty_dict:: {}
 
 # Example
 
-## Why `::`?
+## Why `::`? {#why-two-colons}
 
 1) The indicator `::` immediately makes it apparent that what follows is a vector, to both human readers and parsers. Less guessing.
 


### PR DESCRIPTION
Zola strips certain punctuation from its header IDs (used for linking to them). This includes colons. The colons here are not punctuation, though, but rather content. This leads a URL that looks like:

https://huml.io/specifications/v0-1-0/#why

When linking to one of the more important sections of your readme. Zola supports manual ID specification, though, which solves this issue. (https://www.getzola.org/documentation/content/linking/)