### PR TITLE
For multi-line strings, specify which newlines are preserved.

### DIFF
--- a/content/specifications/v0.1.0.md
+++ b/content/specifications/v0.1.0.md
@@ -121,7 +121,7 @@ Single-line strings may include the following formatting control characters usin
 
 ### Multi-line strings
 
-In multi-line string blocks, no escaping is necessary. Characters are treated literally. As the beginning and ending markers can be derived from the indentation, there is no need to escape the three double quotes or backticks themselves in the string content.
+In multi-line string blocks, all newlines except the one immediately following the opening indicator and preceding the closing indicator are preserved. No escaping is necessary. Characters are treated literally. As the beginning and ending markers can be derived from the indentation, there is no need to escape the three double quotes or backticks themselves in the string content.
 
 #### Preserve spaces: ******` ``` `******
 The content block must be indented by one level (2 spaces) relative to the key. These initial 2 spaces on each line is the minimum required indentation and is not considered as spaces. All other preceding and all trailing spaces are preserved as content. The opening indicator ******` ``` `****** must be after the indicator `:` separated by exactly one space. The closing indicator must be at the indentation level of the key.


### PR DESCRIPTION
Without this clarification, it is unclear whether

````huml
description: ```
  Line 1
  Line 2
```
````

is equivalent to

````huml
description: "Line 1\nLine 2"
````

or

````huml
description: "\nLine 1\nLine 2\n"
````

or something else.