### PR TITLE
Fix playground ignoring initial and end white spaces

### DIFF
--- a/static/static/playground.js
+++ b/static/static/playground.js
@@ -279,7 +279,8 @@ function copyToClipboard(el, side) {
 
 // Set example content for demonstration.
 function setExampleContent() {
-    const str = `# A sample HUML document.
+    const str = `\
+# A sample HUML document.
 website::
   hostname: "huml.io"
   ports:: 80, 443 # Inline list.


### PR DESCRIPTION
1. Removed `.trim()` so that it will not ignore white spaces. As it was trimming white spaces which were ignoring errors.
2. Removed redundant initial blank line and trailing spaces from the end sample huml string

fixes #19 