### PR TITLE
Add huml-dotnet and huml-notepad++ links, fix spec typos

### DIFF
--- a/content/code.md
+++ b/content/code.md
@@ -11,6 +11,7 @@ This page contains links to various HUML-related resources such as parser implem
 
 | Language    | Library                                                                      |
 | ----------- | ---------------------------------------------------------------------------- |
+| Dotnet      | [@primeBeri/huml-dotnet](https://github.com/primeBeri/huml-dotnet)           |
 | Elixir      | [@rahultumpala/huml-ex](https://github.com/rahultumpala/huml-ex)             |
 | Go          | [@huml-lang/go-huml](https://github.com/huml-lang/go-huml)                   |
 | Java        | [@CretanBull/huml4j](https://github.com/CretanBull/huml4j)                   |
@@ -43,6 +44,6 @@ This page contains links to various HUML-related resources such as parser implem
 | [koanf](https://github.com/knadh/koanf) | Configuration management library for Go with HUML support |
 
 ## Tools
-| Name                                | Description                                              |
-| ----------------------------------- | -------------------------------------------------------- |
-| [hq](https://github.com/rhnvrm/hq)  | A jq/yq-like command-line processor for HUML             |
+| Name                               | Description                                  |
+| ---------------------------------- | -------------------------------------------- |
+| [hq](https://github.com/rhnvrm/hq) | A jq/yq-like command-line processor for HUML |

--- a/content/code.md
+++ b/content/code.md
@@ -26,24 +26,25 @@ This page contains links to various HUML-related resources such as parser implem
 | Zig         | [@t0mri/huml](https://codeberg.org/t0mri/huml)                               |
 | Zig         | [@~sphericalkat/humlz](https://git.sr.ht/~sphericalkat/humlz)                |
 
-
-
 ## Plugins and extensions
 
-| Name                                                              | Description                                         |
-| ----------------------------------------------------------------- | --------------------------------------------------- |
-| [huml-vscode](https://github.com/huml-lang/huml-vscode)           | Syntax highlighter extension for Visual Studio Code |
-| [huml-sublime](https://github.com/huml-lang/huml-sublime)         | Syntax highlighter for Sublime Text 3               |
-| [codemirror5-huml](https://github.com/huml-lang/codemirror5-huml) | Syntax highlighter mode for Code Mirror 5           |
-| [vim-huml](https://github.com/huml-lang/vim-huml)                 | Syntax highlighter plugin for vim                   |
-| [huml-lsp](https://github.com/Fred-Milhorn/huml-language-server)  | Language Server Protocol for HUML                   |
+| Name                                                                                                            | Description                                            |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| [huml-vscode](https://github.com/huml-lang/huml-vscode)                                                         | Syntax highlighter extension for Visual Studio Code    |
+| [huml-sublime](https://github.com/huml-lang/huml-sublime)                                                       | Syntax highlighter for Sublime Text 3                  |
+| [codemirror5-huml](https://github.com/huml-lang/codemirror5-huml)                                               | Syntax highlighter mode for Code Mirror 5              |
+| [vim-huml](https://github.com/huml-lang/vim-huml)                                                               | Syntax highlighter plugin for vim                      |
+| [huml-lsp](https://github.com/Fred-Milhorn/huml-language-server)                                                | Language Server Protocol for HUML                      |
+| [huml-notepad++](https://github.com/notepad-plus-plus/userDefinedLanguages/blob/master/UDLs/HUML.Huml-Lang.xml) | Syntax highlighter for Notepad++. Downloadable XML UDL |
 
 ## SDKs
+
 | Name                                    | Description                                               |
 | --------------------------------------- | --------------------------------------------------------- |
 | [koanf](https://github.com/knadh/koanf) | Configuration management library for Go with HUML support |
 
 ## Tools
+
 | Name                               | Description                                  |
 | ---------------------------------- | -------------------------------------------- |
 | [hq](https://github.com/rhnvrm/hq) | A jq/yq-like command-line processor for HUML |

--- a/content/specifications/v0.1.0.md
+++ b/content/specifications/v0.1.0.md
@@ -108,7 +108,7 @@ type: null
 ```
 
 ### Strings
-Strings can only be represented in their canonical (decoded) form. That is, encoded representations such as `\u` and `\U` are not permitted to ensure consitency and readability.
+Strings can only be represented in their canonical (decoded) form. That is, encoded representations such as `\u` and `\U` are not permitted to ensure consistency and readability.
 
 ### Single-line strings
 Single-line strings may include the following formatting control characters using C-style escape notation with backslashes.
@@ -484,7 +484,7 @@ rules as described in the [tokenizer](#tokenizer) section.
 - `|` (e.g. `alpha | digit`) denotes alternatives (OR).
 - `*` (e.g. `rule*`) denotes zero or more repetitions of the preceding element.
 - `+` (e.g. `rule+`) denotes one or more repetitions of the preceding element.
-- `?` (e.g. `rule?`) denotes an optional element (zero or one occurence).
+- `?` (e.g. `rule?`) denotes an optional element (zero or one occurrence).
 - `[...]` describes a range of characters. For example, `['a'..'z']` describes
 the lowercase Latin letters a to z.
 - Single characters are enclosed in single quotes `'` and strings are enclosed

--- a/content/specifications/v0.2.0.md
+++ b/content/specifications/v0.2.0.md
@@ -25,31 +25,31 @@ HUML is tailored for configuration, documents, and datasets.
 
 HUML supports scalar (string, number, bool, null) and vector (list, dict) data types.
 
-| Type        | Description                                                                                                                                            | Example                                                         |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
-| **String**  | Only canonical (decoded) representation of Unicode strings in keys and values. Unicode and hex sctring escaping with `\u`, `\U`, `\x` are not allowed. | Allowed: `"Hello 🌏"`<br>Not allowed: `"Hello \u1F30F"`          |
-|             | **Single-line string value**: Always quoted with double quotes. `"` and `\` must be escaped.                                                           | `"foo"`<br>`"Hello World"`<br>`"Hi \"all\""`<br>`"Back\\Slash"` |
-|             | **Multi-line string value**: Wrapped in `"""` (three double quotes).                                                                                   |                                                                 |
-|             | **Escape sequences**: Standard escape sequences `\n`, `\f`, `\r`, `\t`, `\v` are spported in both keys and values.                                     |                                                                 |
-| **Number**  | **Integer**                                                                                                                                            | `123`, `+123`, `-123`                                           |
-|             | **Float** (64-bit, IEEE 754 double-precision floating-point)                                                                                           | `3.14`, `-0.5`                                                  |
-|             | **Special values**. The special numerical values are unquoted.                                                                                         | `nan`, `inf`, `+inf`, `-inf`                                    |
-|             | *Notations*                                                                                                                                            |                                                                 |
-|             | **Exponent**, denoted by a lowercase `e`                                                                                                               | `1e10`, `6.022e23`                                              |
-|             | **Hex**, begins with `0x`                                                                                                                              | `0x1A`, `0xCAFE`                                                |
-|             | **Octal**, begins with `0o`                                                                                                                            | `0o12`, `0o755`                                                 |
-|             | **Binary**, begins with `0b`                                                                                                                           | `0b1010`, `0b11011001`                                          |
-|             | Numbers can have arbitrary underscore characters for readability, which are simply ignored while parsing.                                              | `1_00_0000`                                                     |
-| **Boolean** | True or false values.                                                                                                                                  | `true`, `false`                                                 |
-| **Null**    | Null value.                                                                                                                                            | `null`                                                          |
-| **List**    | Array of arbitrary data types.                                                                                                                         | `1, 2, "three"`                                                 |
-|             | Definition can be inline or multi-line.                                                                                                                |                                                                 |
-|             | Multi-line items are prefixed with a `-`, like a bullet point list.                                                                                    |                                                                 |
-|             | `[]` is a special signifier used to denote an empty list, e.g., `items:: []`                                                                           | `[]`                                                            |
-| **Dict**    | Unordered map of key-value pairs. Keys are strings and values can be of arbitrary data types.                                                          | `hello: "world", num: 123`                                      |
-|             | Definition can be inline or multi-line.                                                                                                                |                                                                 |
-|             | Duplicate keys inside a dict are not allowed.                                                                                                          |                                                                 |
-|             | `{}` is a special signifier used to denote an empty dict, e.g., `items:: {}`                                                                           | `{}`                                                            |
+| Type        | Description                                                                                                                                           | Example                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| **String**  | Only canonical (decoded) representation of Unicode strings in keys and values. Unicode and hex string escaping with `\u`, `\U`, `\x` are not allowed. | Allowed: `"Hello 🌏"`<br>Not allowed: `"Hello \u1F30F"`        |
+|             | **Single-line string value**: Always quoted with double quotes. `"` and `\` must be escaped.                                                          | `"foo"`<br>`"Hello World"`<br>`"Hi \"all\""`<br>`"Back\\Slash"` |
+|             | **Multi-line string value**: Wrapped in `"""` (three double quotes).                                                                                  |                                                                 |
+|             | **Escape sequences**: Standard escape sequences `\n`, `\f`, `\r`, `\t`, `\v` are supported in both keys and values.                                   |                                                                 |
+| **Number**  | **Integer**                                                                                                                                           | `123`, `+123`, `-123`                                           |
+|             | **Float** (64-bit, IEEE 754 double-precision floating-point)                                                                                          | `3.14`, `-0.5`                                                  |
+|             | **Special values**. The special numerical values are unquoted.                                                                                        | `nan`, `inf`, `+inf`, `-inf`                                    |
+|             | *Notations*                                                                                                                                           |                                                                 |
+|             | **Exponent**, denoted by a lowercase `e`                                                                                                              | `1e10`, `6.022e23`                                              |
+|             | **Hex**, begins with `0x`                                                                                                                             | `0x1A`, `0xCAFE`                                                |
+|             | **Octal**, begins with `0o`                                                                                                                           | `0o12`, `0o755`                                                 |
+|             | **Binary**, begins with `0b`                                                                                                                          | `0b1010`, `0b11011001`                                          |
+|             | Numbers can have arbitrary underscore characters for readability, which are simply ignored while parsing.                                             | `1_00_0000`                                                     |
+| **Boolean** | True or false values.                                                                                                                                 | `true`, `false`                                                 |
+| **Null**    | Null value.                                                                                                                                           | `null`                                                          |
+| **List**    | Array of arbitrary data types.                                                                                                                        | `1, 2, "three"`                                                 |
+|             | Definition can be inline or multi-line.                                                                                                               |                                                                 |
+|             | Multi-line items are prefixed with a `-`, like a bullet point list.                                                                                   |                                                                 |
+|             | `[]` is a special signifier used to denote an empty list, e.g., `items:: []`                                                                          | `[]`                                                            |
+| **Dict**    | Unordered map of key-value pairs. Keys are strings and values can be of arbitrary data types.                                                         | `hello: "world", num: 123`                                      |
+|             | Definition can be inline or multi-line.                                                                                                               |                                                                 |
+|             | Duplicate keys inside a dict are not allowed.                                                                                                         |                                                                 |
+|             | `{}` is a special signifier used to denote an empty dict, e.g., `items:: {}`                                                                          | `{}`                                                            |
 
 ------------
 
@@ -105,7 +105,7 @@ type: null
 ```
 
 ### Strings
-Strings can only be represented in their canonical (decoded) form. That is, encoded representations such as `\u` and `\U` are not permitted to ensure consitency and readability.
+Strings can only be represented in their canonical (decoded) form. That is, encoded representations such as `\u` and `\U` are not permitted to ensure consistency and readability.
 
 ### Single-line strings
 Single-line strings may include the following formatting control characters using C-style escape notation with backslashes.
@@ -453,7 +453,7 @@ rules as described in the [tokenizer](#tokenizer) section.
 - `|` (e.g. `alpha | digit`) denotes alternatives (OR).
 - `*` (e.g. `rule*`) denotes zero or more repetitions of the preceding element.
 - `+` (e.g. `rule+`) denotes one or more repetitions of the preceding element.
-- `?` (e.g. `rule?`) denotes an optional element (zero or one occurence).
+- `?` (e.g. `rule?`) denotes an optional element (zero or one occurrence).
 - `[...]` describes a range of characters. For example, `['a'..'z']` describes
 the lowercase Latin letters a to z.
 - Single characters are enclosed in single quotes `'` and strings are enclosed


### PR DESCRIPTION
## Summary

- Adds [huml-dotnet](https://github.com/primeBeri/huml-dotnet) (.NET implementation) to the Libraries table in `content/code.md`.
- Adds [huml-notepad++](https://github.com/notepad-plus-plus/userDefinedLanguages/blob/master/UDLs/HUML.Huml-Lang.xml) (Notepad++ UDL) to the Plugins and extensions table in `content/code.md`.
- Minor typo corrections in `content/specifications/v0.1.0.md` and `content/specifications/v0.2.0.md`:
  - `sctring` → `string`
  - `spported` → `supported`
  - `consitency` → `consistency`
  - `occurence` → `occurrence`

## Test plan
- [ ] Confirm the new Dotnet row renders in the Libraries table on the rendered Code page.
- [ ] Confirm the new Notepad++ row links correctly to the HUML UDL XML file.
- [ ] Skim the v0.1.0 and v0.2.0 spec pages for the corrected words.